### PR TITLE
Fix: awk: towc: multibyte conversion failure on: '?! '

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -82,7 +82,8 @@ if [[ "${UNINSTALL_FLAG}" == "true" ]]; then
 fi
 
 # Find client version
-CLIENT_VERSION=$(awk '/CFBundleShortVersionString/{getline; print}' "${INSTALL_PATH}/Contents/Info.plist" | cut -d\> -f2- | rev | cut -d. -f2- | rev)
+#Fix Using plutil:"awk: towc: multibyte conversion failure on: '?! '"
+CLIENT_VERSION=$(plutil -p "${INSTALL_PATH}/Contents/Info.plist" | grep CFBundleShortVersionString | awk -F'"' '{print $4}')
 
 # Get Mac OS Architecture
 MAC_ARCH=$(uname -m)


### PR DESCRIPTION
Hello, 
installing spotify with brew and show this problem with awk.

`awk: towc: multibyte conversion failure on: '?! '

 input record number 1, file /Applications/Spotify.app/Contents/Info.plist
 source line number 1

************************
BlockTheSpot-Mac by @Nuzair46
************************

Spotify version: 
BlockTheSpot-Mac version: 1.2.32.985.g3be2709c`

Instead with plutil retrieve the correct value as expected:
./install.sh                                         
Spotify client version: 1.2.45.454

************************
BlockTheSpot-Mac by @Nuzair46
************************

Spotify version: 1.2.45.454
BlockTheSpot-Mac version: 1.2.32.985.g3be2709c

Creating backup...
Extracting xpui...
Applying BlockTheSpot patches...
Removing ad-related content...
Patching Binary...
Removing premium-only features...
Removing logging...
Adding credits...
Signing Spotify...
BlockTheSpot finished patching!
